### PR TITLE
Fix Decrypting Not Working

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -150,11 +150,13 @@ int main( int argc, char *argv[] )
 		if ( stricmp( argv[i], "-e" ) == 0 || stricmp( argv[i], "-encrypt" ) == 0 )
 		{
 			g_bEncrypt = true;
+			g_bDecrypt = false;
 			i++;
 		}
 		else if ( stricmp( argv[i], "-d" ) == 0 || stricmp( argv[i], "-decrypt" ) == 0 )
 		{
 			g_bDecrypt = true;
+			g_bEncrypt = false;
 			i++;
 		}
 		else if ( stricmp( argv[i], "-k" ) == 0 || stricmp( argv[i], "-key" ) == 0 )


### PR DESCRIPTION
Decrypting was failing because g_bEncrypt is assumed to be true by default and was not set to false when the -decrypt argument was passed in. This is now fixed. This does not really deal with potential duplicate arguments, but this fixes the issue.

Fixes Issue #1 

https://github.com/felis-catus/icey/issues/1